### PR TITLE
Fixed the identityprofile missing error

### DIFF
--- a/044-Dapr/README.md
+++ b/044-Dapr/README.md
@@ -148,3 +148,4 @@ You'll specify the ports from the command-line when starting a service with the 
 - Marcelo Silva
 - Rob Vettor
 - Edwin van Wijk
+- Chandrasekar B

--- a/044-Dapr/Student/Resources/Infrastructure/bicep/aks.bicep
+++ b/044-Dapr/Student/Resources/Infrastructure/bicep/aks.bicep
@@ -66,6 +66,9 @@ resource aks 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
       }
     }
   }
+  identity:{
+    type:'SystemAssigned'
+  }
 }
 
 output aksName string = aks.name


### PR DESCRIPTION
Fixed the below error:
                     Provisioning of resource(s) for container service in resource group failed. Required parameter servicePrincipalProfile is missing (null).
